### PR TITLE
Fix endpoint for listing origination requests

### DIFF
--- a/PPPForgivenessSDK/origination.py
+++ b/PPPForgivenessSDK/origination.py
@@ -37,7 +37,7 @@ class OriginationRequestApi(BaseApi):
         assert isinstance(page, int), "Page must be a valid integer"
 
         http_method = "GET"
-        endpoint = "ppp_loan_forgiveness_requests/"
+        endpoint = "origination/"
 
         uri = self.client.api_uri + endpoint
 


### PR DESCRIPTION
The endpoint was pointing to the API to list forgiveness requests. This commit updates it to the API for origination requests.

I am just a user of the system and came across the issue when trying to use the endpoint for listing origination requests.