### PR TITLE
Update origination to allow parameters for schedule C filers

### DIFF
--- a/PPPForgivenessSDK/origination.py
+++ b/PPPForgivenessSDK/origination.py
@@ -110,7 +110,10 @@ class OriginationRequestApi(BaseApi):
             period_1_quarter=None,
             period_2_quarter=None,
             refinance_of_eidl_amount=None,
-            refinance_of_eidl_loan_number=None,            
+            refinance_of_eidl_loan_number=None,
+            schedule_c_2483_form=False,
+            schedule_c_tax_year=None,
+            schedule_c_gross_income=None
         ):
 
         """
@@ -230,7 +233,7 @@ class OriginationRequestApi(BaseApi):
             'refinance_of_eidl_amount': refinance_of_eidl_amount,
             'refinance_of_eidl_loan_number': refinance_of_eidl_loan_number
         }
-        
+
         if second_draw_ppp_loan:
             assert ppp_first_draw_sba_loan_number is not None, 'ppp_first_draw_sba_loan_number can not be None if submitting a Second Draw Loan'
             assert ppp_first_draw_loan_amount is not None, 'ppp_first_draw_loan_amount can not be None if submitting a Second Draw Loan'
@@ -246,6 +249,16 @@ class OriginationRequestApi(BaseApi):
                 'ppp_first_draw_loan_amount': ppp_first_draw_loan_amount
             }
             params.update(second_draw_params)
+
+        if schedule_c_2483_form:
+            assert schedule_c_tax_year is not None, 'schedule_c_tax_year cannot be None if submitting a schedule C form'
+            assert schedule_c_gross_income is not None, 'schedule_c_gross_income cannot be None if submitting a schedule C form'
+
+            schedule_c_params = {
+                'schedule_c_tax_year': schedule_c_tax_year,
+                'schedule_c_gross_income': schedule_c_gross_income
+            }
+            params.update(schedule_c_params)
 
         headers = {'Content-Type': 'application/json'}
         try:

--- a/PPPForgivenessSDK/origination.py
+++ b/PPPForgivenessSDK/origination.py
@@ -28,7 +28,7 @@ class OriginationRequestApi(BaseApi):
         except:
             raise UnknownException # TODO: what about 405?
 
-    def list(self, page=1):
+    def list(self, page=1, page_size=100):
         """
 
         :param page:
@@ -41,7 +41,7 @@ class OriginationRequestApi(BaseApi):
 
         uri = self.client.api_uri + endpoint
 
-        params = {'page': page}
+        params = {'page': page, 'page_size': page_size}
         try:
             response = self.execute(http_method=http_method,
                                     url=uri,

--- a/PPPForgivenessSDK/origination.py
+++ b/PPPForgivenessSDK/origination.py
@@ -231,7 +231,8 @@ class OriginationRequestApi(BaseApi):
             'applicant_no_shuttered_venue_grant': applicant_no_shuttered_venue_grant,
             'loan_request_is_necessary': loan_request_is_necessary,
             'refinance_of_eidl_amount': refinance_of_eidl_amount,
-            'refinance_of_eidl_loan_number': refinance_of_eidl_loan_number
+            'refinance_of_eidl_loan_number': refinance_of_eidl_loan_number,
+            'schedule_c_2483_form': schedule_c_2483_form
         }
 
         if second_draw_ppp_loan:


### PR DESCRIPTION
Made changes so that the SDK can:

- Accept whether the current request is for a schedule C filer
- Assert the presence of and accept schedule C gross income and the corresponding tax year for schedule C submissions